### PR TITLE
Remove team and user mentions from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # code owners
-*  @SrimanPadmanabanCB @middesb
+* @middesb


### PR DESCRIPTION
## Changes

Removed team and individual user mentions from repos we don't own

### Details
- Removed @SrimanPadmanabanCB from CODEOWNERS